### PR TITLE
Update 2023 links, update CFP with most recent topics from the EuroS&P proposal

### DIFF
--- a/2023/index.html
+++ b/2023/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Redirecting...</title>
-  <meta http-equiv="refresh" content="0; url=https://systex24.github.io/">
+  <meta http-equiv="refresh" content="0; url=https://systex.cs.fau.de/systex23/">
 </head>
 <body>
   <p>If you are not redirected automatically, follow this <a href="url=https://systex.cs.fau.de/systex23/">link</a>.</p>

--- a/2025/cfp.html
+++ b/2025/cfp.html
@@ -92,7 +92,7 @@
           <!--       <h4><a href="./docs/CFP-SysTEX2019.txt">Text-only version of the CFP</a></h4> -->
 
           <p>
-          The 8th Workshop on System Software for Trusted Execution (SysTEX) will focus on research challenges related to Trusted Execution Environments (TEEs) and explore new ideas and strategies for implementing trustworthy systems with TEEs. The workshop aims to foster collaboration and discussion among researchers and practitioners in this field. In recent years all major hardware manufacturers have developed some form of TEE support, making this technology widely available in consumer devices today, e.g., Intel SGX, AMD SEV-SNP, ARM TrustZone, IBM Z and PEF. These TEE primitives enable fine-grained and flexible trusted execution, but also introduce numerous novel challenges and opportunities for developers of secure applications. Hence, there is a burning need for cross-cutting systems support and security analysis of such TEEs that span all the layers of the software stack, from the OS through runtime to compilers, programming models, and novel applications. Furthermore, several new TEE extensions, such as Intel TDX, ARM Morello and CCA, NVIDIA Confidential Computing, will soon be available in the market, further pushing the research field of trusted execution. The workshop will also invite discussion on the challenges and opportunities for emerging TEE technologies, such as RISC-V's Keystone and Microsoft's Pluton, and the integration of TEE-based solutions with pervasive 5G networks, IoT, and AI applications.
+          The 8th Workshop on System Software for Trusted Execution (SysTEX) will focus on research challenges related to Trusted Execution Environments (TEEs) and explore new ideas and strategies for implementing trustworthy systems with TEEs. The workshop aims to foster collaboration and discussion among researchers and practitioners in this field. In recent years all major hardware manufacturers have developed some form of TEE support, making this technology widely available in consumer devices today, e.g., Intel SGX/TDX, AMD SEV, ARM TrustZone, IBM Z/PEF or RISC-V. These TEE primitives enable fine-grained and flexible trusted execution, but also introduce numerous novel challenges and opportunities for developers of secure applications. Hence, there is a burning need for cross-cutting systems support and security analysis of such TEEs that span all the layers of the software stack, from the OS through runtime to compilers, programming models, and novel applications. The workshop will also invite discussion on the challenges and opportunities for the integration of TEE-based solutions with pervasive 5G networks, IoT, and AI applications.
           </p>
           <p>Topics of interest include but are not limited to:</p>
 
@@ -114,7 +114,9 @@
             <li>Use case studies of trusted execution</li>
             <li>Intrusion resilience in trusted computing</li>
             <li>Emerging challenges in integrating TEEs with 5G and edge networks</li>
-          </ul>    
+            <li>Confidential AI</li>
+            <li>Secure & trusted supply chains</li>
+          </ul>
 
 
           <h3>Format of the workshop</h3>
@@ -127,7 +129,7 @@
 
           <h3 id="guidelines">Submission Guidelines </h3>
 
-          <p>In line with the call for papers from previous editions, we invite both original research papers, as well as short research statements to encourage discussion at the workshop (as proven successful in last editions). Furthermore, for the upcoming edition, we want to explicitly recognize the importance of high-quality reusable software and hardware tools to aid research in the fast-changing TEE ecosystem (e.g., reverse-engineering and attack frameworks, binary and compiler defenses, open-source enclave processors).</p>
+          <p>In line with the call for papers from previous editions, we invite both original research papers, short research statements to encourage discussion at the workshop (as proven successful in last editions), and papers describing high-quality reusable software and hardware tools to aid research in the fast-changing TEE ecosystem (e.g., reverse-engineering and attack frameworks, binary and compiler defenses, open-source enclave processors).</p>
 
           <p>Thus, SysTEX welcomes submissions in three formats:</p>
 
@@ -147,13 +149,12 @@
 
           <p>At least one author of each accepted paper is required to attend the workshop and present the paper.</p>
 
-
           <p>Submissions site: <strong>Coming Soon</strong> </p>
 
           <h3>Optional Artifact Evaluation</h3>
 
           <p>
-          Recognizing the importance of open science and reproducible artifacts for the security community, authors of accepted papers will be invited to <em>optionally</em> participate in a lightweight artifact evaluation. This initiative aims to add an optional "artifacts evaluated" badge on the website, linking to the corresponding open-source repository. The presence of this badge will not only acknowledge the commitment to open science by the authors but also enhance the visibility of these efforts. 
+          Recognizing the importance of open science and reproducible artifacts for the security community, authors of accepted papers will be invited to <em>optionally</em> participate in a lightweight artifact evaluation. This initiative aims to add an optional "artifacts evaluated" badge on the website, linking to the corresponding open-source repository. The presence of this badge will not only acknowledge the commitment to open science by the authors but also enhance the visibility of these efforts.
           </p>
 
           <p>

--- a/2025/committee.html
+++ b/2025/committee.html
@@ -52,7 +52,7 @@
           <h3>Organizers and contact information</h3>
           <p>PC co-chairs for this year's SysTEX will be:</p>
           <ul>
-            <li><a href="https://vahldiek.github.io/">Anjo Vahldiek-Oberwagner</a>, Intel Labs &amp TU Munich</li>
+            <li><a href="https://vahldiek.github.io/">Anjo Vahldiek-Oberwagner</a>, Intel Labs</li>
             <li><a href="https://marioskogias.github.io/">Marios Kogias</a>, Imperial College London &amp Azure Research</li>
           </ul>
 

--- a/2025/index.html
+++ b/2025/index.html
@@ -67,7 +67,7 @@
               <tbody>
                 <tr>
                   <td><i class="bi bi-alarm" style="font-size: 2em;"></i></td>
-                  <td>February 20, 2025 (23:59 AoE)</td>
+                  <td>February 20, 2025 (23:59 AoE) - no extension</td>
                   <td>Paper submission</td>
                 </tr>
                 <tr>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
       <p><a href="2025/index.html">SysTEX'25</a>, Co-located with EuroS&P'25 June 30 - July 4, 2025, Venice, Italy</p>
       <h3>Past Workshops</h3>
       <p><a href="2024/index.html">SysTEX'24</a>, Co-located with EuroSys'23</p>
+      <p><a href="2023/index.html">SysTEX'23</a>, Co-located with EuroSys'23</p>
       <p><a href="2022/index.html">SysTEX'22</a>, Co-located with ASPLOS'22</p>
       <p><a href="2019/index.html">SysTEX'19</a>, Co-located with SOSP'19</p>
       <p><a href="2018/index.html">SysTEX'18</a>, Co-located with CCS'18</p>


### PR DESCRIPTION
Changes in this PR
* 2023 redirect was linking to 2024 and missing from the landing page.
* Change to affiliation of Anjo (remove TUM)
* Update CFP language based on recent EuroS&P proposal including additional topics of interest